### PR TITLE
Added session identifier property to RKClient. RKClient now explicitly s...

### DIFF
--- a/Classes/Networking/RKClient.h
+++ b/Classes/Networking/RKClient.h
@@ -40,6 +40,11 @@ extern NSString * const RKClientErrorDomain;
 @property (nonatomic, strong) NSString *modhash;
 
 /**
+ The session cookie value for the current user.
+ */
+@property (nonatomic, strong) NSString *sessionIdentifier;
+
+/**
  The user agent for requests sent to reddit.
  */
 @property (nonatomic, strong) NSString *userAgent;

--- a/Classes/Networking/RKClient.m
+++ b/Classes/Networking/RKClient.m
@@ -109,8 +109,10 @@ NSString * const RKClientErrorDomain = @"RKClientErrorDomain";
         {
             NSDictionary *data = responseObject[@"json"][@"data"];
             NSString *modhash = data[@"modhash"];
+            NSString *sessionIdentifier = data[@"cookie"];
             
             [weakSelf setModhash:modhash];
+            [weakSelf setSessionIdentifier:sessionIdentifier];
             
             [weakSelf currentUserWithCompletion:^(id object, NSError *error) {
                 weakSelf.currentUser = object;
@@ -146,13 +148,14 @@ NSString * const RKClientErrorDomain = @"RKClientErrorDomain";
 
 - (BOOL)isSignedIn
 {
-	return self.modhash != nil;
+	return self.modhash != nil && self.sessionIdentifier != nil;
 }
 
 - (void)signOut
 {
 	self.currentUser = nil;
 	self.modhash = nil;
+    self.sessionIdentifier = nil;
     
     NSHTTPCookieStorage *storage = [NSHTTPCookieStorage sharedHTTPCookieStorage];
     NSArray *cookies = [storage cookies];
@@ -171,6 +174,14 @@ NSString * const RKClientErrorDomain = @"RKClientErrorDomain";
 {
     _modhash = [modhash copy];
     [[self requestSerializer] setValue:_modhash forHTTPHeaderField:@"X-Modhash"];
+}
+
+- (void)setSessionIdentifier:(NSString *)sessionIdentifier {
+    
+    _sessionIdentifier = [sessionIdentifier copy];
+    
+    NSString *cookieValue = _sessionIdentifier ? [NSString stringWithFormat:@"reddit_session=%@", [_sessionIdentifier stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] : nil;
+    [[self requestSerializer] setValue:cookieValue forHTTPHeaderField:@"Cookie"];
 }
 
 - (void)setUserAgent:(NSString *)userAgent


### PR DESCRIPTION
...ends the session identifier in the request.

Previously the session identifier was automatically taken from the
cookie store, now we store it ourselves, and add it to the request
cookie header field manually. This fixes problems with
`NSHTTPCookieStorage` from https://github.com/samsymons/RedditKit/issues/2.
