### PR TITLE
Switch back to having AFNetworking as a dependency instead of just the s...

### DIFF
--- a/RedditKit.podspec
+++ b/RedditKit.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/*.{h,m}', 'Classes/**/*.{h,m}' 
   s.header_mappings_dir =  'Classes'
 
-  s.dependency 'AFNetworking/NSURLSession', '~> 2.0'
+  s.dependency 'AFNetworking', '~> 2.0'
   s.dependency 'Mantle', '~> 1.3'
 end


### PR DESCRIPTION
...ubspec AFNetworking/NSURLSession

There are bugs in AFNetworking/NSURLSession which requires it to use
other files not included in the sub spec. There is an issue opened here https://github.com/AFNetworking/AFNetworking/issues/1596
