### PR TITLE
Added pagination to subscribed subreddits.

### DIFF
--- a/Classes/Networking/RKClient+Users.h
+++ b/Classes/Networking/RKClient+Users.h
@@ -71,17 +71,26 @@ typedef NS_ENUM(NSUInteger, RKSubscribedSubredditCategory)
 /**
  Gets the subreddits to which the current user is subscribed.
  
- @param completion The block to be executed upon completion of the request. It takes two arguments: the response array of RKSubreddit objects, and any error that occurred.
+ @param completion The block to be executed upon completion of the request. It takes three arguments: the response array of RKSubreddit objects, an RKPagination object, and any error that occurred.
  */
-- (NSURLSessionDataTask *)subscribedSubredditsWithCompletion:(RKArrayCompletionBlock)completion;
+- (NSURLSessionDataTask *)subscribedSubredditsWithCompletion:(RKListingCompletionBlock)completion;
 
 /**
  Gets the subreddits to which the current user is subscribed.
  
  @param category The category of subreddits to return.
- @param completion The block to be executed upon completion of the request. It takes two arguments: the response array of RKSubreddit objects, and any error that occurred.
+ @param completion The block to be executed upon completion of the request. It takes three arguments: the response array of RKSubreddit objects, an RKPagination object, and any error that occurred.
  */
-- (NSURLSessionDataTask *)subscribedSubredditsInCategory:(RKSubscribedSubredditCategory)category completion:(RKArrayCompletionBlock)completion;
+- (NSURLSessionDataTask *)subscribedSubredditsInCategory:(RKSubscribedSubredditCategory)category completion:(RKListingCompletionBlock)completion;
+
+/**
+ Gets the subreddits to which the current user is subscribed.
+
+ @param category The category of subreddits to return.
+ @param pagination The pagination object to be sent with the request.
+ @param completion The block to be executed upon completion of the request. It takes three arguments: the response array of RKSubreddit objects, an RKPagination object, and any error that occurred.
+ */
+- (NSURLSessionDataTask *)subscribedSubredditsInCategory:(RKSubscribedSubredditCategory)category pagination:(RKPagination *)pagination completion:(RKListingCompletionBlock)completion
 
 /**
  Deletes the current user's account on reddit and signs them out from the RKClient.


### PR DESCRIPTION
I added another method to `RKClient+Users` for pagination on subscribed subreddits:

`- (NSURLSessionDataTask *)subscribedSubredditsInCategory:(RKSubscribedSubredditCategory)category pagination:(RKPagination *)pagination completion:(RKListingCompletionBlock)completion`

I don't know how you currently feel about breaking backwards compatibility, but for this to work I changed the old methods completion blocks to be `RKListingCompletionBlock` instead of `RKArrayCompletionBlock`. Other than that, I just had them filter in to the new method, which only has additions for an `RKPagination` object. Let me know how you feel about these changes.
