### PR TITLE
Fixed bug in RKVotable::voteStatus

### DIFF
--- a/Classes/Model/RKVotable.m
+++ b/Classes/Model/RKVotable.m
@@ -71,7 +71,7 @@
 + (NSValueTransformer *)voteStatusJSONTransformer
 {
     return [MTLValueTransformer transformerWithBlock:^(id forward) {
-        if (!forward)
+        if (!forward || forward == [NSNull null])
         {
             return @(RKVoteStatusNone);
         }


### PR DESCRIPTION
I think one of the new Mantle updates or somewhere in your own code upstream, caused the JSONTransformer in RKVotable to check against [NSNull null] when it should have been checking for nil value. This was causing any post that was not voted on to be registered as downVoted.
