### PR TITLE
Passing back JSON responses for submissions

### DIFF
--- a/Classes/Networking/RKClient+Links.h
+++ b/Classes/Networking/RKClient+Links.h
@@ -148,7 +148,7 @@ typedef NS_ENUM(NSUInteger, RKSubredditCategory) {
  @param captchaValue The optional value of the CAPTCHA you are submitting with this post.
  @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
  */
-- (NSURLSessionDataTask *)submitLinkPostWithTitle:(NSString *)title subreddit:(RKSubreddit *)subreddit URL:(NSURL *)URL captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)submitLinkPostWithTitle:(NSString *)title subreddit:(RKSubreddit *)subreddit URL:(NSURL *)URL captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKObjectCompletionBlock)completion;
 
 /**
  Submits a link post.
@@ -160,7 +160,7 @@ typedef NS_ENUM(NSUInteger, RKSubredditCategory) {
  @param captchaValue The optional value of the CAPTCHA you are submitting with this post.
  @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
  */
-- (NSURLSessionDataTask *)submitLinkPostWithTitle:(NSString *)title subredditName:(NSString *)subredditName URL:(NSURL *)URL captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)submitLinkPostWithTitle:(NSString *)title subredditName:(NSString *)subredditName URL:(NSURL *)URL captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKObjectCompletionBlock)completion;
 
 /**
  Submits a self post.
@@ -172,7 +172,7 @@ typedef NS_ENUM(NSUInteger, RKSubredditCategory) {
  @param captchaValue The optional value of the CAPTCHA you are submitting with this post.
  @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
  */
-- (NSURLSessionDataTask *)submitSelfPostWithTitle:(NSString *)title subreddit:(RKSubreddit *)subreddit text:(NSString *)text captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)submitSelfPostWithTitle:(NSString *)title subreddit:(RKSubreddit *)subreddit text:(NSString *)text captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKObjectCompletionBlock)completion;
 
 /**
  Submits a self post.
@@ -184,7 +184,7 @@ typedef NS_ENUM(NSUInteger, RKSubredditCategory) {
  @param captchaValue The optional value of the CAPTCHA you are submitting with this post.
  @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
  */
-- (NSURLSessionDataTask *)submitSelfPostWithTitle:(NSString *)title subredditName:(NSString *)subredditName text:(NSString *)text captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)submitSelfPostWithTitle:(NSString *)title subredditName:(NSString *)subredditName text:(NSString *)text captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKObjectCompletionBlock)completion;
 
 #pragma mark - Marking NSFW
 

--- a/Classes/Networking/RKClient+Links.m
+++ b/Classes/Networking/RKClient+Links.m
@@ -132,12 +132,12 @@ NSString * NSStringFromSubredditCategory(RKSubredditCategory category)
 
 #pragma mark - Submitting
 
-- (NSURLSessionDataTask *)submitLinkPostWithTitle:(NSString *)title subreddit:(RKSubreddit *)subreddit URL:(NSURL *)URL captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)submitLinkPostWithTitle:(NSString *)title subreddit:(RKSubreddit *)subreddit URL:(NSURL *)URL captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKObjectCompletionBlock)completion
 {
     return [self submitLinkPostWithTitle:title subredditName:subreddit.title URL:URL captchaIdentifier:captchaIdentifier captchaValue:captchaValue completion:completion];
 }
 
-- (NSURLSessionDataTask *)submitLinkPostWithTitle:(NSString *)title subredditName:(NSString *)subredditName URL:(NSURL *)URL captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)submitLinkPostWithTitle:(NSString *)title subredditName:(NSString *)subredditName URL:(NSURL *)URL captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKObjectCompletionBlock)completion
 {
     NSParameterAssert(title);
     NSParameterAssert(subredditName);
@@ -154,15 +154,15 @@ NSString * NSStringFromSubredditCategory(RKSubredditCategory category)
     
     [parameters setObject:@"link" forKey:@"kind"];
     
-    return [self basicPostTaskWithPath:@"api/submit" parameters:parameters completion:completion];
+    return [self basicPostAndResponseTaskWithPath:@"api/submit" parameters:parameters completion:completion];
 }
 
-- (NSURLSessionDataTask *)submitSelfPostWithTitle:(NSString *)title subreddit:(RKSubreddit *)subreddit text:(NSString *)text captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)submitSelfPostWithTitle:(NSString *)title subreddit:(RKSubreddit *)subreddit text:(NSString *)text captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKObjectCompletionBlock)completion
 {
     return [self submitSelfPostWithTitle:title subredditName:subreddit.title text:text captchaIdentifier:captchaIdentifier captchaValue:captchaValue completion:completion];
 }
 
-- (NSURLSessionDataTask *)submitSelfPostWithTitle:(NSString *)title subredditName:(NSString *)subredditName text:(NSString *)text captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)submitSelfPostWithTitle:(NSString *)title subredditName:(NSString *)subredditName text:(NSString *)text captchaIdentifier:(NSString *)captchaIdentifier captchaValue:(NSString *)captchaValue completion:(RKObjectCompletionBlock)completion
 {
     NSParameterAssert(title);
     NSParameterAssert(subredditName);
@@ -178,7 +178,7 @@ NSString * NSStringFromSubredditCategory(RKSubredditCategory category)
     
     [parameters setObject:@"self" forKey:@"kind"];
     
-    return [self basicPostTaskWithPath:@"api/submit" parameters:parameters completion:completion];
+    return [self basicPostAndResponseTaskWithPath:@"api/submit" parameters:parameters completion:completion];
 }
 
 #pragma mark - Marking NSFW

--- a/Classes/Networking/RKClient+Requests.h
+++ b/Classes/Networking/RKClient+Requests.h
@@ -28,6 +28,16 @@ typedef void(^RKRequestCompletionBlock)(NSHTTPURLResponse *response, id response
 @interface RKClient (Requests)
 
 /**
+ Many of reddit's API methods require a set of parameters, return an error if they fail, and something when they succeed.
+ This method eliminates much of the repetition when writing methods around these methods.
+ 
+ @param path The path to request.
+ @param parameters The parameters to pass with the request.
+ @param completion A block to execute at the end of the request.
+ */
+- (NSURLSessionDataTask *)basicPostAndResponseTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKObjectCompletionBlock)completion;
+
+/**
  Many of reddit's API methods require a set of parameters and simply return an error if they fail, and nothing (of value, at least) when they succeed.
  This method eliminates much of the repetition when writing methods around these methods.
  

--- a/Classes/Networking/RKClient+Requests.m
+++ b/Classes/Networking/RKClient+Requests.m
@@ -27,7 +27,7 @@
 
 @implementation RKClient (Requests)
 
-- (NSURLSessionDataTask *)basicPostTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)basicPostAndResponseTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKObjectCompletionBlock)completion
 {
     NSParameterAssert(path);
     
@@ -36,7 +36,7 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             if (completion)
             {
-                completion([RKClient authenticationRequiredError]);
+                completion(nil, [RKClient authenticationRequiredError]);
             }
         });
         
@@ -44,6 +44,18 @@
     }
     
     return [self postPath:path parameters:parameters completion:^(NSHTTPURLResponse *response, id responseObject, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (completion)
+            {
+                completion(responseObject, error);
+            }
+        });
+    }];
+}
+
+- (NSURLSessionDataTask *)basicPostTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKCompletionBlock)completion
+{
+    return [self basicPostAndResponseTaskWithPath:path parameters:parameters completion:^(id object, NSError *error) {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (completion)
             {


### PR DESCRIPTION
API responds w/ 200 even if subreddits don't exist.
By passing back the `responseObject`, the client can properly handle errors passed back within the JSON reponse.

Fixes #26
