### PR TITLE
Fixed an issue with an odd reddit api response.

### DIFF
--- a/Classes/Networking/RKResponseSerializer.m
+++ b/Classes/Networking/RKResponseSerializer.m
@@ -55,7 +55,7 @@
     
     // Parse the response:
     
-    if (responseString && ![responseString isEqualToString:@" "])
+    if (responseString && ![responseString isEqualToString:@" "] && ![responseString isEqualToString:@"\"{}\""])
     {
         return [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:error];
     }


### PR DESCRIPTION
For some odd reason, when attempting to retrieve messages in the category `RKMessageCategoryAll`, the reddit api would respond with `"{}"` if the user has not authenticated yet. This was crashing in `objectsFromListingResponse`, because that response was parsed into an `NSString` by the json parser. I added a catch for this specific response to skip parsing and return nil. Let me know if you think this is an acceptable solution or something else should be done.
