### PR TITLE
Fixed issue where HTML entities in URL were not escaped.

### DIFF
--- a/Classes/Model/RKLink.m
+++ b/Classes/Model/RKLink.m
@@ -99,16 +99,16 @@
 + (NSValueTransformer *)URLJSONTransformer
 {
     return [MTLValueTransformer transformerWithBlock:^(NSString *URL) {
-        NSString *escapedURL = [URL stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        return [NSURL URLWithString:escapedURL];
+        NSString *unescapedURL = [[URL stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] stringByUnescapingHTMLEntities];
+        return [NSURL URLWithString:unescapedURL];
     }];
 }
 
 + (NSValueTransformer *)permalinkJSONTransformer
 {
     return [MTLValueTransformer transformerWithBlock:^(NSString *permalink) {
-        NSString *escapedPermalink = [permalink stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
-        NSString *fullPermalink = [NSString stringWithFormat:@"http://reddit.com%@", escapedPermalink];
+        NSString *unescapedPermalink = [[permalink stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding] stringByUnescapingHTMLEntities];
+        NSString *fullPermalink = [NSString stringWithFormat:@"http://reddit.com%@", unescapedPermalink];
         
         return [NSURL URLWithString:fullPermalink];
     }];


### PR DESCRIPTION
I may be wrong, but it seems HTML entities aren't escaped in URLs.

For example, for this link: https://www.youtube.com/watch?feature=player_embedded&v=DPAw3McLayc

RedditKit returns: https://www.youtube.com/watch?feature=player_embedded&amp;v=DPAw3McLayc

(Note the `&amp;` instead of `&`.)

I simply used the existing `NSString+HTML.h` class to unescape the HTML entities in `RKLink`. (Also, shouldn't it be `unescapedLink` not `escapedLink`?)
