### PR TITLE
Added: search subreddit names for autocomplete suggestions

### DIFF
--- a/Classes/Networking/RKClient+Requests.h
+++ b/Classes/Networking/RKClient+Requests.h
@@ -60,6 +60,29 @@ typedef void(^RKRequestCompletionBlock)(NSHTTPURLResponse *response, id response
 - (NSURLSessionDataTask *)fullListingWithPath:(NSString *)path parameters:(NSDictionary *)parameters pagination:(RKPagination *)pagination completion:(RKObjectCompletionBlock)completion;
 
 /**
+ This method makes a request for a listing and converts the response into objects.
+ 
+ @param path The path to request.
+ @param parameters The parameters to pass with the request.
+ @param pagination The optional pagination object.
+ @param completion A block to execute at the end of the request.
+ */
+- (NSURLSessionDataTask *)postListingTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters pagination:(RKPagination *)pagination completion:(RKListingCompletionBlock)completion;
+
+/**
+ This method makes a request for a listing and returns the full response.
+ This is in contrast to listingTaskWithPath:parameters:pagination:completion: which returns
+ a listing in its formatted state, with all JSON parsed.
+ 
+ @param path The path to request.
+ @param parameters The parameters to pass with the request.
+ @param pagination The optional pagination object.
+ @param completion A block to execute at the end of the request.
+ */
+- (NSURLSessionDataTask *)fullPostListingWithPath:(NSString *)path parameters:(NSDictionary *)parameters pagination:(RKPagination *)pagination completion:(RKObjectCompletionBlock)completion;
+
+
+/**
  This method wraps around the 'api/friend' API, as many different methods are based on this endpoint.
  
  @param container The 'container' parameter.
@@ -87,6 +110,12 @@ typedef void(^RKRequestCompletionBlock)(NSHTTPURLResponse *response, id response
  Extracts RKThing subclasses from a listing response.
  */
 - (NSArray *)objectsFromListingResponse:(NSDictionary *)listingResponse;
+
+/**
+ Extracts names from a listing response.
+ */
+- (NSArray *)namesFromListingResponse:(NSDictionary *)listingResponse;
+
 
 #pragma mark - Request Helpers
 

--- a/Classes/Networking/RKClient+Search.h
+++ b/Classes/Networking/RKClient+Search.h
@@ -62,4 +62,15 @@
  */
 - (NSURLSessionDataTask *)search:(NSString *)query subredditName:(NSString *)subredditName restrictSubreddit:(BOOL)restrictSubreddit pagination:(RKPagination *)pagination completion:(RKListingCompletionBlock)completion;
 
+
+/**
+ Gets subreddit autocomplete suggestions.
+ 
+ @param query The subreddit name
+ @param includeOver18 Whether to include adult subreddits
+ @see: http://www.reddit.com/dev/api#POST_api_search_reddit_names.json
+ */
+
+- (NSURLSessionDataTask *)searchRedditNames:(NSString *)query includeOver18:(BOOL)includeOver18 pagination:(RKPagination *)pagination completion:(RKListingCompletionBlock)completion;
+
 @end

--- a/Classes/Networking/RKClient+Search.m
+++ b/Classes/Networking/RKClient+Search.m
@@ -48,4 +48,15 @@
     return [self listingTaskWithPath:path parameters:parameters pagination:pagination completion:completion];
 }
 
+- (NSURLSessionDataTask *)searchRedditNames:(NSString *)query includeOver18:(BOOL)includeOver18 pagination:(RKPagination *)pagination completion:(RKListingCompletionBlock)completion
+{
+    NSParameterAssert(query);
+    
+    NSString *path = @"api/search_reddit_names.json";
+    NSString *over18String = [self stringFromBoolean:includeOver18];
+    NSDictionary *parameters = @{@"query": query, @"include_over_18": over18String };
+    
+    return [self postListingTaskWithPath:path parameters:parameters pagination:pagination completion:completion];
+}
+
 @end


### PR DESCRIPTION
Added: search subreddit names for autocomplete suggestions, e.g. "pol" -> politics. Existing version of RedditKit only supports API to recommend related subreddits, e.g. "politics" -> "ukpolitics".
Added supporting functions: listing request from POST rather than GET; parse listing returned as "name" dictionary
