### PR TITLE
Clean up name of listingTaskWithPath method (with Array block completion).

### DIFF
--- a/Classes/Networking/RKClient+Comments.m
+++ b/Classes/Networking/RKClient+Comments.m
@@ -89,7 +89,7 @@
                                  };
     NSString *path = [NSString stringWithFormat:@"comments/%@.json", linkIdentifier];
     
-    return [self commentsListingTaskWithPath:path parameters:parameters completion:completion];
+    return [self listingTaskWithPath:path parameters:parameters completion:completion];
 }
 
 - (NSURLSessionDataTask *)moreComments:(RKMoreComments *)moreComments forLink:(RKLink *)link sort:(RKCommentSortingMethod)sort completion:(RKArrayCompletionBlock)completion

--- a/Classes/Networking/RKClient+Requests.h
+++ b/Classes/Networking/RKClient+Requests.h
@@ -47,13 +47,13 @@ typedef void(^RKRequestCompletionBlock)(NSHTTPURLResponse *response, id response
 - (NSURLSessionDataTask *)postMoreCommentsListingTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKArrayCompletionBlock)completion;
 
 /**
- This method makes a request for a comments listing and converts the response into objects.
+ This method makes a request for a listing and converts the response into objects.
  
  @param path The path to request.
  @param parameters The parameters to pass with the request.
  @param completion A block to execute at the end of the request.
  */
-- (NSURLSessionDataTask *)commentsListingTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKArrayCompletionBlock)completion;
+- (NSURLSessionDataTask *)listingTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKArrayCompletionBlock)completion;
 
 /**
  This method makes a request for a listing and converts the response into objects.

--- a/Classes/Networking/RKClient+Requests.m
+++ b/Classes/Networking/RKClient+Requests.m
@@ -91,7 +91,7 @@
     }];
 }
 
-- (NSURLSessionDataTask *)commentsListingTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKArrayCompletionBlock)completion
+- (NSURLSessionDataTask *)listingTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKArrayCompletionBlock)completion
 {
     NSParameterAssert(path);
     
@@ -110,10 +110,10 @@
                     response = [responseObject lastObject];
                 }
                 
-                NSArray *links = [self objectsFromListingResponse:response];
+                NSArray *objects = [self objectsFromListingResponse:response];
                 
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    completion(links, nil);
+                    completion(objects, nil);
                 });
             });
         }


### PR DESCRIPTION
Make the name more generic since it can be used for more than just fetching comments.