### PR TITLE
Update local state for save/hide operations

### DIFF
--- a/Classes/Networking/RKClient+Links.m
+++ b/Classes/Networking/RKClient+Links.m
@@ -284,7 +284,16 @@ NSString * RKStringFromSubredditCategory(RKSubredditCategory category)
 
 - (NSURLSessionDataTask *)hideLink:(RKLink *)link completion:(RKCompletionBlock)completion
 {
-    return [self hideLinkWithFullName:[link fullName] completion:completion];
+    return [self hideLinkWithFullName:[link fullName] completion:^(NSError *error) {
+        if (!error) {
+            RKLink *object = [RKLink modelWithDictionary:@{ @"hidden": @YES } error:nil];
+            [link mergeValueForKey:@"hidden" fromModel:object];
+        }
+        
+        if (completion) {
+            completion(error);
+        }
+    }];
 }
 
 - (NSURLSessionDataTask *)hideLinkWithFullName:(NSString *)fullName completion:(RKCompletionBlock)completion
@@ -297,7 +306,16 @@ NSString * RKStringFromSubredditCategory(RKSubredditCategory category)
 
 - (NSURLSessionDataTask *)unhideLink:(RKLink *)link completion:(RKCompletionBlock)completion
 {
-    return [self unhideLinkWithFullName:[link fullName] completion:completion];
+    return [self unhideLinkWithFullName:[link fullName] completion:^(NSError *error) {
+        if (!error) {
+            RKLink *object = [RKLink modelWithDictionary:@{ @"hidden": @NO } error:nil];
+            [link mergeValueForKey:@"hidden" fromModel:object];
+        }
+        
+        if (completion) {
+            completion(error);
+        }
+    }];
 }
 
 - (NSURLSessionDataTask *)unhideLinkWithFullName:(NSString *)fullName completion:(RKCompletionBlock)completion

--- a/Classes/Networking/RKClient+Miscellaneous.m
+++ b/Classes/Networking/RKClient+Miscellaneous.m
@@ -52,12 +52,30 @@
 
 - (NSURLSessionDataTask *)saveLink:(RKLink *)link completion:(RKCompletionBlock)completion
 {
-    return [self saveLinkOrCommentWithFullName:[link fullName] completion:completion];
+    return [self saveLinkOrCommentWithFullName:[link fullName] completion:^(NSError *error) {
+        if (!error) {
+            RKLink *newLink = [RKLink modelWithDictionary:@{ @"saved": @YES } error:nil];
+            [link mergeValueForKey:@"saved" fromModel:newLink];
+        }
+        
+        if (completion) {
+            completion(error);
+        }
+    }];
 }
 
 - (NSURLSessionDataTask *)saveComment:(RKComment *)comment completion:(RKCompletionBlock)completion
 {
-    return [self saveLinkOrCommentWithFullName:[comment fullName] completion:completion];
+    return [self saveLinkOrCommentWithFullName:[comment fullName] completion:^(NSError *error) {
+        if (!error) {
+            RKLink *object = [RKLink modelWithDictionary:@{ @"saved": @YES } error:nil];
+            [comment mergeValueForKey:@"saved" fromModel:object];
+        }
+        
+        if (completion) {
+            completion(error);
+        }
+    }];
 }
 
 - (NSURLSessionDataTask *)saveLinkOrCommentWithFullName:(NSString *)fullName completion:(RKCompletionBlock)completion
@@ -70,12 +88,30 @@
 
 - (NSURLSessionDataTask *)unsaveLink:(RKLink *)link completion:(RKCompletionBlock)completion
 {
-    return [self unsaveLinkOrCommentWithFullName:[link fullName] completion:completion];
+    return [self unsaveLinkOrCommentWithFullName:[link fullName] completion:^(NSError *error) {
+        if (!error) {
+            RKLink *object = [RKLink modelWithDictionary:@{ @"saved": @NO } error:nil];
+            [link mergeValueForKey:@"saved" fromModel:object];
+        }
+        
+        if (completion) {
+            completion(error);
+        }
+    }];
 }
 
 - (NSURLSessionDataTask *)unsaveComment:(RKComment *)comment completion:(RKCompletionBlock)completion
 {
-    return [self unsaveLinkOrCommentWithFullName:[comment fullName] completion:completion];
+    return [self unsaveLinkOrCommentWithFullName:[comment fullName] completion:^(NSError *error) {
+        if (!error) {
+            RKLink *object = [RKLink modelWithDictionary:@{ @"saved": @NO } error:nil];
+            [comment mergeValueForKey:@"saved" fromModel:object];
+        }
+        
+        if (completion) {
+            completion(error);
+        }
+    }];
 }
 
 - (NSURLSessionDataTask *)unsaveLinkOrCommentWithFullName:(NSString *)fullName completion:(RKCompletionBlock)completion


### PR DESCRIPTION
This change makes it so that when a user saves/unsaves a link or comment, or hides/unhides a link, changes are reflected locally upon successful API request. This is more or less how voting works already.