### PR TITLE
Add support to handle the (undocumented?) bare bones, 't1' comment HTTP response object returned from 'api/comment' (aka "Submit Comment" API).

### DIFF
--- a/Classes/Model/RKComment.h
+++ b/Classes/Model/RKComment.h
@@ -147,4 +147,34 @@ typedef NS_ENUM(NSUInteger, RKDistinguishedStatus) {
  */
 - (BOOL)isDeleted;
 
+/**
+ Note: This data is only sent back from reddit's API as a response to submitting a new comment.
+ 
+ The body text of the comment, as Markdown.
+ */
+@property (nonatomic, copy, readonly) NSString *submissionContentText;
+
+/**
+ Note: This data is only sent back from reddit's API as a response to submitting a new comment.
+ 
+ The body text of the comment, as HTML.
+ */
+@property (nonatomic, copy, readonly) NSString *submissionContentHTML;
+
+/**
+ Note: This data is only sent back from reddit's API as a response to submitting a new comment.
+ 
+ The identifier of the link to which this comment was posted.
+ */
+@property (nonatomic, copy, readonly) NSString *submissionLink;
+
+/**
+ Note: This data is only sent back from reddit's API as a response to submitting a new comment.
+ 
+ The identifier of the comment's parent. It can be the link if it's a top-level comment. Otherwise
+ the parent can be a comment, if it's a reply.
+ */
+@property (nonatomic, copy, readonly) NSString *submissionParent;
+
+
 @end

--- a/Classes/Model/RKComment.m
+++ b/Classes/Model/RKComment.m
@@ -46,7 +46,11 @@
         @"controversiality": @"controversiality",
         @"parentID": @"data.parent_id",
         @"subreddit": @"data.subreddit",
-        @"subredditID": @"data.subreddit_id"
+        @"subredditID": @"data.subreddit_id",
+		@"submissionContentText": @"data.contentText", // Note: This data is only sent back from reddit's API as a response to submitting a new comment.
+		@"submissionContentHTML": @"data.contentHTML", // Note: This data is only sent back from reddit's API as a response to submitting a new comment.
+		@"submissionLink": @"data.link", // Note: This data is only sent back from reddit's API as a response to submitting a new comment.
+		@"submissionParent": @"data.parent" // Note: This data is only sent back from reddit's API as a response to submitting a new comment.
         //		@"totalReports": @"data.num_reports",          // not required for now.
         //		@"distinguishedStatus": @"data.distinguished", // not required for now.
     };
@@ -56,7 +60,13 @@
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p, author: %@, parentID: %@, fullName: %@, replies: %lu>", NSStringFromClass([self class]), self, self.author, self.parentID, self.fullName, (unsigned long)self.replies.count];
+	// The following is just a way to show the content of a comment that represents either a "real" comment vs. a "submission" comment response received
+	// after calling the submitComment:onThingWithFullName:forLink:finished: API. I'm totally open to another approach if anyone has any suggestions
+	// and/or is familiar with what I'm talking about.
+	NSString *parentIDString = self.parentID ? @"parentID" : @"parent";
+	NSString *fullNameIDString = self.parentID ? @"fullName" : @"identifier";
+	
+	return [NSString stringWithFormat:@"<%@: %p, author: %@, %@: %@, %@: %@, replies: %lu>", NSStringFromClass([self class]), self, self.author, parentIDString, self.parentID ? self.submissionParent : self.submissionParent, fullNameIDString, self.parentID ? self.fullName : self.identifier, (unsigned long)self.replies.count];
 }
 
 - (BOOL)isDeleted

--- a/Classes/Networking/RKClient+Comments.h
+++ b/Classes/Networking/RKClient+Comments.h
@@ -33,30 +33,30 @@
  
  @param commentText The body of the comment, as Markdown.
  @param link The link on which to comment.
- @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
+ @param completion An optional block to be executed upon request completion. It takes two arguments: a bare-bones RKComment response representing the actual comment that was submitted, and any error that occurred.
  @return The NSURLSessionDataTask for the request.
  */
-- (NSURLSessionDataTask *)submitComment:(NSString *)commentText onLink:(RKLink *)link completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)submitComment:(NSString *)commentText onLink:(RKLink *)link completion:(RKObjectCompletionBlock)completion;
 
 /**
  Submit a comment as a reply to another comment.
  
  @param commentText The body of the comment, as Markdown.
  @param comment The comment.
- @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
+ @param completion An optional block to be executed upon request completion. It takes two arguments: a bare-bones RKComment response representing the actual comment that was submitted, and any error that occurred.
  @return The NSURLSessionDataTask for the request.
  */
-- (NSURLSessionDataTask *)submitComment:(NSString *)commentText asReplyToComment:(RKComment *)comment completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)submitComment:(NSString *)commentText asReplyToComment:(RKComment *)comment completion:(RKObjectCompletionBlock)completion;
 
 /**
  Submit a comment on a link or ocmment.
  
  @param commentText The body of the comment, as Markdown.
  @param fullName The full name of the link or comment.
- @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
+ @param completion An optional block to be executed upon request completion. It takes two arguments: a bare-bones RKComment response representing the actual comment that was submitted, and any error that occurred.
  @return The NSURLSessionDataTask for the request.
  */
-- (NSURLSessionDataTask *)submitComment:(NSString *)commentText onThingWithFullName:(NSString *)fullName completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)submitComment:(NSString *)commentText onThingWithFullName:(NSString *)fullName completion:(RKObjectCompletionBlock)completion;
 
 #pragma mark - Getting Comments
 

--- a/Classes/Networking/RKClient+Comments.m
+++ b/Classes/Networking/RKClient+Comments.m
@@ -33,24 +33,24 @@
 
 #pragma mark - Submitting Comments
 
-- (NSURLSessionDataTask *)submitComment:(NSString *)commentText onLink:(RKLink *)link completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)submitComment:(NSString *)commentText onLink:(RKLink *)link completion:(RKObjectCompletionBlock)completion
 {
     return [self submitComment:commentText onThingWithFullName:[link fullName] completion:completion];
 }
 
-- (NSURLSessionDataTask *)submitComment:(NSString *)commentText asReplyToComment:(RKComment *)comment completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)submitComment:(NSString *)commentText asReplyToComment:(RKComment *)comment completion:(RKObjectCompletionBlock)completion
 {
     return [self submitComment:commentText onThingWithFullName:[comment fullName] completion:completion];
 }
 
-- (NSURLSessionDataTask *)submitComment:(NSString *)commentText onThingWithFullName:(NSString *)fullName completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)submitComment:(NSString *)commentText onThingWithFullName:(NSString *)fullName completion:(RKObjectCompletionBlock)completion
 {
     NSParameterAssert(commentText);
     NSParameterAssert(fullName);
     
     NSDictionary *parameters = @{@"text": commentText, @"thing_id": fullName};
     
-    return [self basicPostTaskWithPath:@"api/comment" parameters:parameters completion:completion];
+    return [self postSubmitCommentTaskWithPath:@"api/comment" parameters:parameters completion:completion];
 }
 
 #pragma mark - Getting Comments

--- a/Classes/Networking/RKClient+Requests.h
+++ b/Classes/Networking/RKClient+Requests.h
@@ -38,6 +38,15 @@ typedef void(^RKRequestCompletionBlock)(NSHTTPURLResponse *response, id response
 - (NSURLSessionDataTask *)basicPostTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKCompletionBlock)completion;
 
 /**
+ This method wraps around the 'api/comment' API (aka "Submit Comment" API), using parameters set into the body of an HTTP POST request.
+ 
+ @param path The path to request.
+ @param parameters The parameters to pass with the request.
+ @param completion A block to execute at the end of the request.
+ */
+- (NSURLSessionDataTask *)postSubmitCommentTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKObjectCompletionBlock)completion;
+
+/**
  This method wraps around the 'api/morechildren' API, using parameters set into the body of an HTTP POST request.
  
  @param path The path to request.


### PR DESCRIPTION
You can now get the HTTP response data representing the bare essentials of a newly submitted comment created when calling the ```submitComment:onThingWithFullName:completion:``` (aka ```'api/comment'```) API. The undocumented (at least as far as I can tell) reddit ```'t1'``` JSON property keys returned in the HTTP response, and their Objective-C property mappings, are as follows:

JSON Key | Obj-C Property
------------- | -------------
"data.contentText" | submissionContentText
"data.contentHTML" | submissionContentHTML
"data.link"        | submissionLink
"data.parent"      | submissionParent

The ```'api/comment'``` HTTP response object does not return the other properties that would normally be seen in a "run-of-the-mill" ```'t1'``` comment JSON object.

/to @samsymons 