### PR TITLE
Editing comments and self posts: Handle the bare bones 't1' comment HTTP response object returned from the 'api/editusertext' API.

### DIFF
--- a/Classes/Model/RKComment.m
+++ b/Classes/Model/RKComment.m
@@ -66,7 +66,7 @@
 	NSString *parentIDString = self.parentID ? @"parentID" : @"parent";
 	NSString *fullNameIDString = self.parentID ? @"fullName" : @"identifier";
 	
-	return [NSString stringWithFormat:@"<%@: %p, author: %@, %@: %@, %@: %@, replies: %lu>", NSStringFromClass([self class]), self, self.author, parentIDString, self.parentID ? self.submissionParent : self.submissionParent, fullNameIDString, self.parentID ? self.fullName : self.identifier, (unsigned long)self.replies.count];
+	return [NSString stringWithFormat:@"<%@: %p, author: %@, %@: %@, %@: %@, replies: %lu>", NSStringFromClass([self class]), self, self.author, parentIDString, self.parentID ?: self.submissionParent, fullNameIDString, self.parentID ? self.fullName : self.identifier, (unsigned long)self.replies.count];
 }
 
 - (BOOL)isDeleted

--- a/Classes/Model/RKSubreddit.h
+++ b/Classes/Model/RKSubreddit.h
@@ -33,7 +33,9 @@ typedef NS_ENUM(NSUInteger, RKSubredditType) {
     RKSubredditTypePrivate,
     RKSubredditTypeRestricted,
     RKSubredditTypeGoldRestricted,
-    RKSubredditTypeArchived
+	RKSubredditTypeGoldOnly,
+    RKSubredditTypeArchived,
+	RKSubredditTypeEmployeesOnly
 };
 
 typedef NS_ENUM(NSUInteger, RKSpamFilterStrength) {

--- a/Classes/Model/RKSubreddit.m
+++ b/Classes/Model/RKSubreddit.m
@@ -148,7 +148,9 @@
         @"private": @(RKSubredditTypePrivate),
         @"restricted": @(RKSubredditTypeRestricted),
         @"gold_restricted": @(RKSubredditTypeGoldRestricted),
-        @"archived": @(RKSubredditTypeArchived)
+		@"gold_only": @(RKSubredditTypeGoldOnly),
+        @"archived": @(RKSubredditTypeArchived),
+		@"employees_only": @(RKSubredditTypeEmployeesOnly)
     };
     
     return [MTLValueTransformer transformerWithBlock:^(NSString *type) {

--- a/Classes/Networking/RKClient+Comments.m
+++ b/Classes/Networking/RKClient+Comments.m
@@ -50,7 +50,7 @@
     
     NSDictionary *parameters = @{@"text": commentText, @"thing_id": fullName};
     
-    return [self postSubmitCommentTaskWithPath:@"api/comment" parameters:parameters completion:completion];
+    return [self postSubmitCommentOrEditUserTextTaskWithPath:@"api/comment" parameters:parameters completion:completion];
 }
 
 #pragma mark - Getting Comments

--- a/Classes/Networking/RKClient+Miscellaneous.h
+++ b/Classes/Networking/RKClient+Miscellaneous.h
@@ -34,27 +34,27 @@
  
  @param link The link to edit.
  @param text The text to be set as the self post's body. This will replace the old text.
- @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
+ @param completion An optional block to be executed upon request completion. It takes two arguments: a bare-bones response representing the actual self post that was submitted, and any error that occurred.
  */
-- (NSURLSessionDataTask *)editSelfPost:(RKLink *)link newText:(NSString *)text completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)editSelfPost:(RKLink *)link newText:(NSString *)text completion:(RKObjectCompletionBlock)completion;
 
 /**
  Edits a comment created by the current user.
  
  @param comment The comment to edit.
  @param text The text to be set as the comment's body. This will replace the old text.
- @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
+ @param completion An optional block to be executed upon request completion. It takes two arguments: a bare-bones response representing the actual comment that was submitted, and any error that occurred.
  */
-- (NSURLSessionDataTask *)editComment:(RKComment *)comment newText:(NSString *)text completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)editComment:(RKComment *)comment newText:(NSString *)text completion:(RKObjectCompletionBlock)completion;
 
 /**
  Edits a self post or a comment created by the current user.
  
  @param fullName The full name of the self post or comment.
  @param text The text to be set as the body. This will replace the old text.
- @param completion An optional block to be executed upon request completion. Its only argument is any error that occurred.
+ @param completion An optional block to be executed upon request completion. It takes two arguments: a bare-bones response representing the actual self post or comment that was submitted, and any error that occurred.
  */
-- (NSURLSessionDataTask *)editSelfPostOrCommentWithFullName:(NSString *)fullName newText:(NSString *)text completion:(RKCompletionBlock)completion;
+- (NSURLSessionDataTask *)editSelfPostOrCommentWithFullName:(NSString *)fullName newText:(NSString *)text completion:(RKObjectCompletionBlock)completion;
 
 #pragma mark - Saving
 

--- a/Classes/Networking/RKClient+Miscellaneous.m
+++ b/Classes/Networking/RKClient+Miscellaneous.m
@@ -29,23 +29,23 @@
 
 #pragma mark - Editing
 
-- (NSURLSessionDataTask *)editSelfPost:(RKLink *)link newText:(NSString *)text completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)editSelfPost:(RKLink *)link newText:(NSString *)text completion:(RKObjectCompletionBlock)completion
 {
     return [self editSelfPostOrCommentWithFullName:[link fullName] newText:text completion:completion];
 }
 
-- (NSURLSessionDataTask *)editComment:(RKComment *)comment newText:(NSString *)text completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)editComment:(RKComment *)comment newText:(NSString *)text completion:(RKObjectCompletionBlock)completion
 {
     return [self editSelfPostOrCommentWithFullName:[comment fullName] newText:text completion:completion];
 }
 
-- (NSURLSessionDataTask *)editSelfPostOrCommentWithFullName:(NSString *)fullName newText:(NSString *)text completion:(RKCompletionBlock)completion
+- (NSURLSessionDataTask *)editSelfPostOrCommentWithFullName:(NSString *)fullName newText:(NSString *)text completion:(RKObjectCompletionBlock)completion
 {
     NSParameterAssert(fullName);
     NSParameterAssert(text);
     
     NSDictionary *parameters = @{ @"text": text, @"thing_id": fullName, @"uh": self.modhash };
-    return [self basicPostTaskWithPath:@"api/editusertext" parameters:parameters completion:completion];
+	return [self postSubmitCommentOrEditUserTextTaskWithPath:@"api/editusertext" parameters:parameters completion:completion];
 }
 
 #pragma mark - Saving

--- a/Classes/Networking/RKClient+Requests.h
+++ b/Classes/Networking/RKClient+Requests.h
@@ -38,13 +38,13 @@ typedef void(^RKRequestCompletionBlock)(NSHTTPURLResponse *response, id response
 - (NSURLSessionDataTask *)basicPostTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKCompletionBlock)completion;
 
 /**
- This method wraps around the 'api/comment' API (aka "Submit Comment" API), using parameters set into the body of an HTTP POST request.
+ This method wraps around the 'api/comment' API (aka "Submit Comment" API) and/or the "api/editusertext" API, using parameters set into the body of an HTTP POST request.
  
  @param path The path to request.
  @param parameters The parameters to pass with the request.
  @param completion A block to execute at the end of the request.
  */
-- (NSURLSessionDataTask *)postSubmitCommentTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKObjectCompletionBlock)completion;
+- (NSURLSessionDataTask *)postSubmitCommentOrEditUserTextTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKObjectCompletionBlock)completion;
 
 /**
  This method wraps around the 'api/morechildren' API, using parameters set into the body of an HTTP POST request.

--- a/Classes/Networking/RKClient+Requests.m
+++ b/Classes/Networking/RKClient+Requests.m
@@ -53,7 +53,7 @@
     }];
 }
 
-- (NSURLSessionDataTask *)postSubmitCommentTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKObjectCompletionBlock)completion
+- (NSURLSessionDataTask *)postSubmitCommentOrEditUserTextTaskWithPath:(NSString *)path parameters:(NSDictionary *)parameters completion:(RKObjectCompletionBlock)completion
 {
 	NSParameterAssert(path);
 	
@@ -85,10 +85,10 @@
 						response = [responseObject lastObject];
 					}
 					
-					NSArray *commentsAndMoreComments = [self objectsFromMoreCommentsListingResponse:responseObject];
+					NSArray *dataThingsResponseObjects = [self objectsFromDataThingsListingResponse:responseObject];
 					
 					dispatch_async(dispatch_get_main_queue(), ^{
-						completion([commentsAndMoreComments firstObject], nil);
+						completion([dataThingsResponseObjects firstObject], nil);
 					});
 				});
 			}
@@ -123,7 +123,7 @@
                         response = [responseObject lastObject];
                     }
                     
-                    NSArray *commentsAndMoreComments = [self objectsFromMoreCommentsListingResponse:response];
+                    NSArray *commentsAndMoreComments = [self objectsFromDataThingsListingResponse:response];
                     
                     dispatch_async(dispatch_get_main_queue(), ^{
                         completion(commentsAndMoreComments, nil);
@@ -357,7 +357,7 @@
     return [objects copy];
 }
 
-- (NSArray *)objectsFromMoreCommentsListingResponse:(NSDictionary *)listingResponse
+- (NSArray *)objectsFromDataThingsListingResponse:(NSDictionary *)listingResponse
 {
     NSParameterAssert(listingResponse);
     


### PR DESCRIPTION
This change extends the support initially made in pull request #65 (commit @8042847) for submitting comments using the 'api/comment' API to now also supporting the HTTP response object returned when editing comments and self posts.

Update: Added a new commit to fix a crash when processing subreddits whose subreddit_type is "gold_only" or "employees_only".

/to @samsymons 

![reddit_com__api_documentation](https://cloud.githubusercontent.com/assets/449168/7447293/1f3cf9f0-f1aa-11e4-9a39-412952621967.jpg)
