### PR TITLE
Fixes issue with thumbnails that come back as booleans.

### DIFF
--- a/Classes/Model/RKLink.m
+++ b/Classes/Model/RKLink.m
@@ -128,7 +128,7 @@
 + (NSValueTransformer *)thumbnailURLJSONTransformer
 {
     return [MTLValueTransformer transformerWithBlock:^id(NSString *thumbnailURL) {
-        if ([thumbnailURL isEqualToString:@"self"])
+        if (![thumbnailURL isKindOfClass:[NSString class]] || [thumbnailURL isEqualToString:@"self"])
         {
             return nil;
         }


### PR DESCRIPTION
For some reason, sometimes links come back in the api as thumbnails set to `false`. This fixes a crash when that happens.