### PR TITLE
Add OAuth refreshToken methods to RKClient

### DIFF
--- a/Classes/Model/RKOAuthCredential.h
+++ b/Classes/Model/RKOAuthCredential.h
@@ -20,6 +20,11 @@
 @property (nonatomic, strong) NSString *clientIdentifier;
 
 /**
+ The OAuth redirect URI from reddit's OAuth application page.
+ */
+@property (nonatomic, strong) NSURL *redirectURI;
+
+/**
  The OAuth authorization code returned by reddit's callback to the current app.
 
  @note This is used when retrieving an access token.

--- a/Classes/Networking/RKClient+Errors.h
+++ b/Classes/Networking/RKClient+Errors.h
@@ -60,6 +60,11 @@ extern const NSInteger RKClientErrorTimedOut;
 + (NSError *)authenticationRequiredError;
 
 /**
+ Returns an error that occurs when retrieving the OAuth access token fails because of an invalid grant.
+ */
++ (NSError *)invalidOAuthGrantError;
+
+/**
  Returns an error that occurs when the current client does not have the appropriate OAuth privileges.
  */
 + (NSError *)invalidOAuthScopeError;

--- a/Classes/Networking/RKClient+Errors.h
+++ b/Classes/Networking/RKClient+Errors.h
@@ -59,6 +59,8 @@ extern const NSInteger RKClientErrorTimedOut;
  */
 + (NSError *)authenticationRequiredError;
 
++ (NSError *)invalidOAuthRequestError;
+
 /**
  Returns an error that occurs when retrieving the OAuth access token fails because of an invalid grant.
  */

--- a/Classes/Networking/RKClient+Errors.m
+++ b/Classes/Networking/RKClient+Errors.m
@@ -143,6 +143,12 @@ const NSInteger RKClientErrorTimedOut = 504;
     return [NSError errorWithDomain:RKClientErrorDomain code:RKClientErrorAuthenticationFailed userInfo:userInfo];
 }
 
++ (NSError *)invalidOAuthGrantError
+{
+    NSDictionary *userInfo = [RKClient userInfoWithDescription:@"Invalid OAuth grant" failureReason:@"Ensure that you are not attempting to re-use old codes - they are one time use."];
+    return [NSError errorWithDomain:RKClientErrorDomain code:RKClientErrorAuthenticationFailed userInfo:userInfo];
+}
+
 + (NSError *)invalidOAuthScopeError
 {
     NSDictionary *userInfo = [RKClient userInfoWithDescription:@"Invalid OAuth scope" failureReason:@"Your current authorization token does not have a valid scope."];

--- a/Classes/Networking/RKClient+Errors.m
+++ b/Classes/Networking/RKClient+Errors.m
@@ -143,6 +143,12 @@ const NSInteger RKClientErrorTimedOut = 504;
     return [NSError errorWithDomain:RKClientErrorDomain code:RKClientErrorAuthenticationFailed userInfo:userInfo];
 }
 
++ (NSError *)invalidOAuthRequestError
+{
+    NSDictionary *userInfo = [RKClient userInfoWithDescription:@"Invalid OAuth request" failureReason:@"Ensure that you are not attempting to re-use old codes - they are one time use."];
+    return [NSError errorWithDomain:RKClientErrorDomain code:RKClientErrorAuthenticationFailed userInfo:userInfo];
+}
+
 + (NSError *)invalidOAuthGrantError
 {
     NSDictionary *userInfo = [RKClient userInfoWithDescription:@"Invalid OAuth grant" failureReason:@"Ensure that you are not attempting to re-use old codes - they are one time use."];

--- a/Classes/Networking/RKClient+OAuth.h
+++ b/Classes/Networking/RKClient+OAuth.h
@@ -14,9 +14,9 @@
  Provides an authentication URL to present within a web view.
  This allows the user to authenticate and grant access to your application.
  */
-- (NSURL *)authenticationURLWithScope:(RKOAuthScope)scope redirectURI:(NSString *)redirectURI;
+- (NSURL *)authenticationURLWithScope:(RKOAuthScope)scope;
 
-- (NSURL *)authenticationURLWithScope:(RKOAuthScope)scope redirectURI:(NSString *)redirectURI state:(NSString *)state compact:(BOOL)compact;
+- (NSURL *)authenticationURLWithScope:(RKOAuthScope)scope state:(NSString *)state compact:(BOOL)compact;
 
 /**
  Parses a redirect URI from reddit and configures the current RKClient with

--- a/Classes/Networking/RKClient+OAuth.h
+++ b/Classes/Networking/RKClient+OAuth.h
@@ -19,11 +19,17 @@
 - (NSURL *)authenticationURLWithScope:(RKOAuthScope)scope state:(NSString *)state compact:(BOOL)compact;
 
 /**
+ Parses a redirect URI and verifies that it matches the redirectURI assigned to 
+ this RKClient.
+ */
+- (BOOL)isRedirectURI:(NSURL *)redirectURI;
+
+/**
  Parses a redirect URI from reddit and configures the current RKClient with
  the appropriate authorization.
  */
-- (BOOL)handleRedirectURI:(NSURL *)redirectURI;
-
+- (void)handleRedirectURI:(NSURL *)redirectURI completion:(RKObjectCompletionBlock)completion
+;
 /**
  Retrieves an OAuth access token using the current authorization code.
  */
@@ -33,6 +39,16 @@
  Retrieves an OAuth access token using a custom authorization code.
  */
 - (NSURLSessionDataTask *)retrieveAccessTokenWithAuthorizationCode:(NSString *)authorizationCode completion:(RKObjectCompletionBlock)completion;
+
+/**
+ Refreshes the OAuth access token using a custom authorization refresh code.
+ */
+- (NSURLSessionDataTask *)refreshAccessTokenWithCompletion:(RKObjectCompletionBlock)completion;
+
+/**
+ Refreshes the OAuth access token using a custom authorization refresh code.
+ */
+- (NSURLSessionDataTask *)refreshAccessTokenWithCompletion:(NSString *)refreshToken completion:(RKObjectCompletionBlock)completion;
 
 - (BOOL)hasScope:(RKOAuthScope)scope;
 

--- a/Classes/Networking/RKClient+OAuth.m
+++ b/Classes/Networking/RKClient+OAuth.m
@@ -46,7 +46,12 @@
     // duration = For mobile apps, this is always set to `permanent`
     // scope = The authorization scope string passed into this method
 
-    NSString *URL = [[NSString alloc] initWithFormat:@"https://ssl.reddit.com/api/v1/authorize?client_id=%@&response_type=code&state=RedditKit&redirect_uri=%@&duration=permanent&scope=%@", self.authorizationCredential.clientIdentifier, redirectURI, scopeString];
+    NSString *authorizeString = @"authorize";
+    if (compact) {
+        authorizeString = @"authorize.compact";
+    }
+
+    NSString *URL = [[NSString alloc] initWithFormat:@"https://ssl.reddit.com/api/v1/%@?client_id=%@&response_type=code&state=RedditKit&redirect_uri=%@&duration=permanent&scope=%@", authorizeString, self.authorizationCredential.clientIdentifier, redirectURI, scopeString];
     
     return [NSURL URLWithString:URL];
 }

--- a/Classes/Networking/RKClient+Requests.m
+++ b/Classes/Networking/RKClient+Requests.m
@@ -442,7 +442,7 @@
     }
     
     NSURLSessionDataTask *task = [self dataTaskWithRequest:request completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
-        if ([responseObject valueForKey:@"error"] && [[responseObject valueForKey:@"error"] integerValue] == 401) {
+        if ([responseObject isKindOfClass:[NSDictionary class]] && [[responseObject objectForKey:@"error"] integerValue] == 401) {
             NSLog(@"Access token expired. Fetching new token.");
             
             [self refreshAccessTokenWithCompletion:^(id object, NSError *error) {

--- a/Classes/Networking/RKClient+Requests.m
+++ b/Classes/Networking/RKClient+Requests.m
@@ -22,6 +22,7 @@
 
 #import "RKClient+Requests.h"
 #import "RKClient+Errors.h"
+#import "RKClient+OAuth.h"
 #import "RKPagination.h"
 #import "RKObjectBuilder.h"
 
@@ -441,6 +442,16 @@
     }
     
     NSURLSessionDataTask *task = [self dataTaskWithRequest:request completionHandler:^(NSURLResponse *response, id responseObject, NSError *error) {
+        if ([responseObject valueForKey:@"error"] && [[responseObject valueForKey:@"error"] integerValue] == 401) {
+            NSLog(@"Access token expired. Fetching new token.");
+            
+            [self refreshAccessTokenWithCompletion:^(id object, NSError *error) {
+                [self taskWithMethod:method path:path parameters:parameters completion:completion];
+            }];
+            
+            return;
+        }
+        
         NSDictionary *headers = [((NSHTTPURLResponse *)response) allHeaderFields];
         
         self.rateLimitedRequestsUsed = [[headers objectForKey:@"x-ratelimit-remaining"] intValue];

--- a/Classes/Networking/RKClient.h
+++ b/Classes/Networking/RKClient.h
@@ -133,7 +133,13 @@ extern NSString * const RKClientErrorDomain;
  */
 - (NSURLSessionDataTask *)signInWithUsername:(NSString *)username password:(NSString *)password completion:(RKCompletionBlock)completion;
 
-- (void)authenticateWithClientIdentifier:(NSString *)clientIdentifier;
+/**
+ Specifies your OAuth client identifier and redirect URI when authenticating with OAuth.
+ 
+ @param clientIdentifier Your applications client identifier.
+ @param password Your applications redirect URI.
+ */
+- (void)authenticateWithClientIdentifier:(NSString *)clientIdentifier redirectURI:(NSURL *)redirectURI;
 
 /**
  Updates the current user. This is useful for getting updated karma totals, or checking whether they have unread private messages.

--- a/Classes/Networking/RKClient.m
+++ b/Classes/Networking/RKClient.m
@@ -142,10 +142,11 @@ NSString * const RKClientErrorDomain = @"RKClientErrorDomain";
     return authenticationTask;
 }
 
-- (void)authenticateWithClientIdentifier:(NSString *)clientIdentifier
+- (void)authenticateWithClientIdentifier:(NSString *)clientIdentifier redirectURI:(NSURL *)redirectURI
 {
     RKOAuthCredential *credential = [[RKOAuthCredential alloc] init];
     credential.clientIdentifier = clientIdentifier;
+    credential.redirectURI = redirectURI;
 
     self.authorizationCredential = credential;
 }

--- a/Classes/Networking/RKClient.m
+++ b/Classes/Networking/RKClient.m
@@ -227,7 +227,7 @@ NSString * const RKClientErrorDomain = @"RKClientErrorDomain";
     [[self requestSerializer] setAuthorizationHeaderFieldWithUsername:authorizationCredential.clientIdentifier password:@""];
 
     if (authorizationCredential.accessToken.accessToken) {
-        NSLog(@"Setting authorization code: %@", authorizationCredential.accessToken.accessToken);
+        NSLog(@"Setting authorization code: %@ and refresh token: %@", authorizationCredential.accessToken.accessToken, authorizationCredential.accessToken.refreshToken);
 
         NSString *value = [[NSString alloc] initWithFormat:@"bearer %@", authorizationCredential.accessToken.accessToken];
         [[self requestSerializer] setValue:value forHTTPHeaderField:@"Authorization"];

--- a/Example/Example/BrowserViewController.h
+++ b/Example/Example/BrowserViewController.h
@@ -20,7 +20,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+@class BrowserViewController;
+
+@protocol BrowserViewControllerDelegate <NSObject>
+
+@optional
+- (void)browserViewControllerDidAuthenticate:(BrowserViewController *)viewController;
+
+@end
+
 @interface BrowserViewController : UIViewController <UIWebViewDelegate>
+
+@property (nonatomic, weak) id <BrowserViewControllerDelegate> delegate;
 
 - (instancetype)initWithLink:(RKLink *)link;
 - (instancetype)initWithURL:(NSURL *)URL;

--- a/Example/Example/BrowserViewController.m
+++ b/Example/Example/BrowserViewController.m
@@ -203,4 +203,19 @@
     self.navigationItem.title = [webView stringByEvaluatingJavaScriptFromString:@"document.title"];
 }
 
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+{
+    if ([[RKClient sharedClient] handleRedirectURI:request.URL]) {
+        [[RKClient sharedClient] retrieveAccessTokenWithCompletion:^(id object, NSError *error) {
+            if (self.delegate && [self.delegate respondsToSelector:@selector(browserViewControllerDidAuthenticate:)]) {
+                [self.delegate browserViewControllerDidAuthenticate:self];
+            }
+        }];
+        
+        return NO;
+    }
+    
+    return YES;
+}
+
 @end

--- a/Example/Example/FrontPageViewController.m
+++ b/Example/Example/FrontPageViewController.m
@@ -29,7 +29,7 @@
 
 static NSString * const kLinkCellReuseIdentifier = @"kLinkCellReuseIdentifier";
 
-@interface FrontPageViewController () <UIActionSheetDelegate>
+@interface FrontPageViewController () <UIActionSheetDelegate, BrowserViewControllerDelegate>
 
 @property (nonatomic, strong) NSArray *links;
 @property (nonatomic, strong) RKPagination *currentPagination;
@@ -129,11 +129,12 @@ static NSString * const kLinkCellReuseIdentifier = @"kLinkCellReuseIdentifier";
 
 - (void)showAuthenticationPage
 {
-    [[RKClient sharedClient] authenticateWithClientIdentifier:@"zeZtZ4A8c71d8w"];
+    [[RKClient sharedClient] authenticateWithClientIdentifier:@"zeZtZ4A8c71d8w" redirectURI:[NSURL URLWithString:@"redditkit://oauth"]];
 
     RKOAuthScope scope = RKOAuthScopeSubreddits|RKOAuthScopeRead;
-    NSURL *authenticationURL = [[RKClient sharedClient] authenticationURLWithScope:scope redirectURI:@"redditkit://oauth"];
+    NSURL *authenticationURL = [[RKClient sharedClient] authenticationURLWithScope:scope];
     BrowserViewController *browserViewController = [[BrowserViewController alloc] initWithURL:authenticationURL];
+    browserViewController.delegate = self;
 
     UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:browserViewController];
     [self presentViewController:navigationController animated:YES completion:nil];
@@ -318,6 +319,18 @@ static NSString * const kLinkCellReuseIdentifier = @"kLinkCellReuseIdentifier";
         self.currentCategory = ((RKSubredditCategory)buttonIndex + 1);
         [self resetLinks];
     }
+}
+
+#pragma mark - BrowserViewControllerDelegate
+
+- (void)browserViewControllerDidAuthenticate:(BrowserViewController *)viewController
+{
+    [self.navigationController dismissViewControllerAnimated:YES completion:^{
+        self.navigationItem.leftBarButtonItem = nil;
+        
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Authenticated!" message:nil delegate:nil cancelButtonTitle:nil otherButtonTitles:@"OK", nil];
+        [alert show];
+    }];
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ RKLink *link = [[self links] firstObject];
 
 ## OAuth
 
-RedditKit 2.0 supports authentication via OAuth. To begin, call `authenticateWithClientIdentifier:` on an instance of `RKClient`. Once you have given RedditKit your client identifier,  you will need to obtain a URL to present to the user, allowing them to sign in their account and grant your app access.
+RedditKit 2.0 supports authentication via OAuth. To begin, call `authenticateWithClientIdentifier:redirectURI:` on an instance of `RKClient`. Once you have given RedditKit your client identifier and redirect URI,  you will need to obtain a URL to present to the user, allowing them to sign in their account and grant your app access.
 
 ```
 RKOAuthScope scope = RKOAuthScopeSubreddits|RKOAuthScopeRead;
@@ -88,6 +88,8 @@ This URL uses a redirect URI to pass data back to your app. Here, you have two o
 2. Present the URL inside `UIWebView` and capture the redirect via its delegate methods
 
 The second option provides a better user experience, and is how the RedditKit demo application does it.
+
+The next step is to retrieve the temporary OAuth code from Reddit, via the URL they have redirected. You can handle this step by calling `handleRedirectURI:` on an instance of `RKClient`. Finally, you can call `retrieveAccessTokenWithCompletion:` which will fetch the access token and save it for future requests. 
 
 ## More Examples
 


### PR DESCRIPTION
...and automatically refresh the token when any request gets a 401 error.

Let me know your thoughts on this. I believe we might need to pause/cancel all other tasks in the queue, if any exist, when we receive a 401 error.